### PR TITLE
cleaning the CD-staging pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,13 +10,7 @@ on:
       - testing
 
   workflow_dispatch:
-    inputs:
-      STAGING_RESOURCE_GROUP:
-        description: "Resource group for staging environment"
-        required: true
-      STAGING_AKS_CLUSTER:
-        description: "AKS cluster name for staging"
-        required: true
+
 jobs:
   # Job 1: Deploy to Staging Environment (runs only if image build and push succeesd)
   deploy_staging:


### PR DESCRIPTION
Deleted the STAGING_RESOURCE_GROUP and STAGING_AKS_CLUSTER inputs from the workflow_dispatch trigger in cd.yml as they are no longer required.